### PR TITLE
Update Index.md (Getting code while using Windows)

### DIFF
--- a/docs/developers-guide/running-from-sources/analysis-platform/index.md
+++ b/docs/developers-guide/running-from-sources/analysis-platform/index.md
@@ -29,7 +29,7 @@ mkdir scava
 cd scava
 git init
 git config core.longpaths true
-git add remote origin https://github.com/eclipse-researchlabs/scava.git
+git remote add origin https://github.com/eclipse-researchlabs/scava.git
 git fetch
 git checkout dev
 ````


### PR DESCRIPTION
The git command git add remote origin https://github.com/eclipse-researchlabs/scava.git should be
: git remote add origin https://github.com/eclipse-researchlabs/scava.git 
since git add remote would throw error since it is entirely different from git remote add which is right command.